### PR TITLE
fix #30 (unique ID is based on device name not MAC address)

### DIFF
--- a/custom_components/bms_ble/binary_sensor.py
+++ b/custom_components/bms_ble/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BTBmsConfigEntry
+from .const import DOMAIN
 from .coordinator import BTBmsCoordinator
 
 BINARY_SENSOR_TYPES: list[BinarySensorEntityDescription] = [
@@ -32,17 +33,22 @@ async def async_setup_entry(
 
     bms: BTBmsCoordinator = config_entry.runtime_data
     for descr in BINARY_SENSOR_TYPES:
-        async_add_entities([BMSBinarySensor(bms, descr)])
+        async_add_entities(
+            [BMSBinarySensor(bms, descr, format_mac(config_entry.unique_id))]
+        )
 
 
 class BMSBinarySensor(CoordinatorEntity[BTBmsCoordinator], BinarySensorEntity):  # type: ignore[reportIncompatibleMethodOverride]
     """The generic BMS binary sensor implementation."""
 
     def __init__(
-        self, bms: BTBmsCoordinator, descr: BinarySensorEntityDescription
+        self,
+        bms: BTBmsCoordinator,
+        descr: BinarySensorEntityDescription,
+        unique_id: str,
     ) -> None:
         """Intialize BMS binary sensor."""
-        self._attr_unique_id = f"{format_mac(bms.name)}-{descr.key}"
+        self._attr_unique_id = f"{DOMAIN}-{unique_id}-{descr.key}"
         self._attr_device_info = bms.device_info
         self._attr_has_entity_name = True
         self.entity_description = descr

--- a/custom_components/bms_ble/sensor.py
+++ b/custom_components/bms_ble/sensor.py
@@ -35,6 +35,7 @@ from .const import (
     ATTR_POWER,
     ATTR_RSSI,
     ATTR_RUNTIME,
+    DOMAIN,
     KEY_CELL_VOLTAGE,
 )
 from .coordinator import BTBmsCoordinator
@@ -131,7 +132,7 @@ async def async_setup_entry(
 
     bms: BTBmsCoordinator = config_entry.runtime_data
     for descr in SENSOR_TYPES:
-        async_add_entities([BMSSensor(bms, descr)])
+        async_add_entities([BMSSensor(bms, descr, format_mac(config_entry.unique_id))])
 
 
 class BMSSensor(CoordinatorEntity[BTBmsCoordinator], SensorEntity):  # type: ignore[reportIncompatibleMethodOverride]
@@ -139,9 +140,11 @@ class BMSSensor(CoordinatorEntity[BTBmsCoordinator], SensorEntity):  # type: ign
 
     _attr_has_entity_name = True
 
-    def __init__(self, bms: BTBmsCoordinator, descr: SensorEntityDescription) -> None:
+    def __init__(
+        self, bms: BTBmsCoordinator, descr: SensorEntityDescription, unique_id: str
+    ) -> None:
         """Intitialize the BMS sensor."""
-        self._attr_unique_id = f"{format_mac(bms.name)}-{descr.key}"
+        self._attr_unique_id = f"{DOMAIN}-{unique_id}-{descr.key}"
         self._attr_device_info = bms.device_info
         self.entity_description = descr
         super().__init__(bms)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from custom_components.bms_ble.const import (
     BMS_TYPES,
     DOMAIN,
 )
-from custom_components.bms_ble.plugins.basebms import BaseBMS
+from custom_components.bms_ble.plugins.basebms import BaseBMS, BMSsample
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -154,12 +154,21 @@ class Mock_BMS(BaseBMS):
     """Mock Battery Management System."""
 
     def __init__(
-        self, exc: Exception | None = None, ret_value: dict | None = None
+        self, exc: Exception | None = None, ret_value: BMSsample | None = None
     ) -> None:  # , ble_device, reconnect: bool = False
         """Initialize BMS."""
         LOGGER.debug("%s init(), Test except: %s", self.device_id(), str(exc))
         self._exception = exc
-        self._ret_value = ret_value
+        self._ret_value: BMSsample = (
+            ret_value
+            if ret_value is not None
+            else {
+                ATTR_VOLTAGE: 13,
+                ATTR_CURRENT: 1.7,
+                ATTR_CYCLE_CHRG: 19,
+                ATTR_CYCLES: 23,
+            }
+        )  # set fixed values for dummy battery
 
     @staticmethod
     def matcher_dict_list() -> list[dict[str, Any]]:
@@ -174,20 +183,12 @@ class Mock_BMS(BaseBMS):
     async def disconnect(self) -> None:
         """Disconnect connection to BMS if active."""
 
-    async def async_update(self) -> dict[str, int | float | bool]:
+    async def async_update(self) -> BMSsample:
         """Update battery status information."""
         if self._exception:
             raise self._exception
 
-        if self._ret_value is not None:
-            return self._ret_value
-        
-        return {
-            ATTR_VOLTAGE: 13,
-            ATTR_CURRENT: 1.7,
-            ATTR_CYCLE_CHRG: 19,
-            ATTR_CYCLES: 23,
-        }  # set fixed values for dummy battery
+        return self._ret_value
 
 
 class MockBleakClient(BleakClient):


### PR DESCRIPTION
changed unique_id format for sensors to contain MAC instead of name
added function to migrate old entries