### PR TITLE
fixed maximum runtime value

### DIFF
--- a/custom_components/bms_ble/plugins/ogt_bms.py
+++ b/custom_components/bms_ble/plugins/ogt_bms.py
@@ -153,6 +153,10 @@ class BMS(BaseBMS):
             {ATTR_CYCLE_CAP, ATTR_POWER, ATTR_BATTERY_CHARGING, ATTR_DELTA_VOLTAGE},
         )
 
+        # remove remaining runtime if battery is charging
+        if self._values.get(ATTR_RUNTIME) == 0xFFFF*60:
+            del self._values[ATTR_RUNTIME]
+
         if self._reconnect:
             # disconnect after data update to force reconnect next time (slow!)
             await self.disconnect()


### PR DESCRIPTION
BMS reports 0xFFFF for runtime in case battery is charging. Map this value to "unknown" as for the other BMSs for better scaled history graphs.