### PR TITLE
Fix for code scanning alert no. 1-5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -1,4 +1,6 @@
 name: Run fuzz tests
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,5 +1,8 @@
 name: Validate with hassfest
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: "Lint the code"
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  '0 5 * * 6'
-  
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,8 @@
 name: Validate with HACS
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:
@@ -16,4 +19,3 @@ jobs:
           uses: "hacs/action@main"
           with:
             category: "integration"
-


### PR DESCRIPTION
Potential fix for [https://github.com/patman15/BMS_BLE-HA/security/code-scanning/5](https://github.com/patman15/BMS_BLE-HA/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (validation with HACS), it likely only needs `contents: read` permission to access the repository's contents. This change will ensure that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
