### PR TITLE
Detect LiTime Redodo batteries

### DIFF
--- a/custom_components/bms_ble/plugins/redodo_bms.py
+++ b/custom_components/bms_ble/plugins/redodo_bms.py
@@ -40,7 +40,7 @@ class BMS(BaseBMS):
                 "manufacturer_id": 0x585A,
                 "connectable": True,
             }
-            for pattern in ("R-12*", "R-24*", "P-12*", "P-24*", "PQ-12*", "PQ-24*")
+            for pattern in ("R-12*", "R-24*", "P-12*", "P-24*", "PQ-12*", "PQ-24*", "L-12*")
         ]
 
     @staticmethod

--- a/custom_components/bms_ble/plugins/redodo_bms.py
+++ b/custom_components/bms_ble/plugins/redodo_bms.py
@@ -40,7 +40,18 @@ class BMS(BaseBMS):
                 "manufacturer_id": 0x585A,
                 "connectable": True,
             }
-            for pattern in ("R-12*", "R-24*", "P-12*", "P-24*", "PQ-12*", "PQ-24*", "L-12*")
+            for pattern in (
+                "R-12*",
+                "R-24*",
+                "RO-12*",
+                "RO-24*",
+                "P-12*",
+                "P-24*",
+                "PQ-12*",
+                "PQ-24*",
+                "L-12*",  # LiTime
+                "L-24*",  # LiTime
+            )
         ]
 
     @staticmethod

--- a/tests/advertisement_data.py
+++ b/tests/advertisement_data.py
@@ -163,7 +163,7 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
     (  # source advmon (https://github.com/patman15/BMS_BLE-HA/issues/350)
         generate_advertisement_data(
             local_name="LT-24100B-A00249",
-            manufacturer_data= {22618:"\xc8\x47\x80\x0b\xb6\x54"},
+            manufacturer_data={22618: "\xc8\x47\x80\x0b\xb6\x54"},
             rssi=-55,
         ),
         "ej_bms",
@@ -399,7 +399,9 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
     (  # source LOG, proxy (https://github.com/patman15/BMS_BLE-HA/issues/164#issue-2825586172)
         generate_advertisement_data(
             local_name="ECO-WORTHY 02_B8EF",
-            manufacturer_data={49844: b"\xe0\xfa\xb8\xf0"},  # MAC address, correct, public
+            manufacturer_data={
+                49844: b"\xe0\xfa\xb8\xf0"
+            },  # MAC address, correct, public
             service_uuids=[
                 "00001800-0000-1000-8000-00805f9b34fb",
                 "00001801-0000-1000-8000-00805f9b34fb",
@@ -552,7 +554,9 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
     (  # source BTctl (https://github.com/patman15/BMS_BLE-HA/issues/253)
         generate_advertisement_data(
             local_name="ECO-WORTHY 02_50DB",
-            manufacturer_data={47912: b"\xed\x00\x50\xdc"},  # MAC address, correct, public
+            manufacturer_data={
+                47912: b"\xed\x00\x50\xdc"
+            },  # MAC address, correct, public
             rssi=-49,
         ),
         "ecoworthy_bms",
@@ -603,7 +607,9 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
     (  # source advmon (https://github.com/patman15/BMS_BLE-HA/issues/286)
         generate_advertisement_data(
             local_name="ECO-WORTHY 0B_5AD4",
-            manufacturer_data={57570: b"\x5a\x78\x3c\x31"},  # MAC address, correct, private
+            manufacturer_data={
+                57570: b"\x5a\x78\x3c\x31"
+            },  # MAC address, correct, private
             service_uuids=["0000fff0-0000-1000-8000-00805f9b34fb"],
             rssi=-86,
         ),
@@ -623,7 +629,9 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
     (  # source proxy LOG (https://github.com/patman15/BMS_BLE-HA/issues/295)
         generate_advertisement_data(
             local_name="ECO-WORTHY 02_3DDF",
-            manufacturer_data={15996: b"\x82\x1c\x3d\xe0"},  # MAC address, correct, public
+            manufacturer_data={
+                15996: b"\x82\x1c\x3d\xe0"
+            },  # MAC address, correct, public
             rssi=-49,
         ),
         "ecoworthy_bms",
@@ -707,5 +715,23 @@ ADVERTISEMENTS: Final[list[tuple[AdvertisementData, str]]] = [
             rssi=-87,
         ),
         "ej_bms",
+    ),
+    (  # source advmon (https://github.com/patman15/BMS_BLE-HA/issues/370)
+        generate_advertisement_data(
+            local_name="L-12100BNNA70-A09683",
+            rssi=-46,
+            manufacturer_data={22618: b"\xc8\x47\x80\x15\xde\x04"},
+            service_uuids=["0000ffe0-0000-1000-8000-00805f9b34fb"],
+        ),
+        "redodo_bms",
+    ),
+    (  # source advmon (https://github.com/patman15/BMS_BLE-HA/issues/367)
+        generate_advertisement_data(
+            local_name="RO-24100B-A00162",
+            rssi=-45,
+            manufacturer_data={22618: b"\xc8\x47\x80\x12\xd5\xe7"},
+            service_uuids=["0000ffe0-0000-1000-8000-00805f9b34fb"],
+        ),
+        "redodo_bms",
     ),
 ]


### PR DESCRIPTION
I have two LiTime 12 Volt 100Ah Mini Smart batteries which weren't detected by this integration. After some trial and error, I found that the Redodo plugin works perfectly for them.

Here is how the batteries show up on the advertisement monitor:

```json
{"name":"L-12100BNNA60-B00077","address":"C8:47:80:22:9B:B8","rssi":-46,"manufacturer_data":{"22618":"c84780229bb8"},"service_data":{},"service_uuids":["00001800-0000-1000-8000-00805f9b34fb","00001801-0000-1000-8000-00805f9b34fb","0000180a-0000-1000-8000-00805f9b34fb","0000180f-0000-1000-8000-00805f9b34fb","0000ffe0-0000-1000-8000-00805f9b34fb","f000ffc0-0451-4000-b000-000000000000"],"source":"B8:27:EB:DF:94:2D","connectable":true,"time":1749604130.0694773,"tx_power":null}
```