### PR TITLE
fix wr mode selection without reply

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,5 @@ repos:
     rev: v1.17.0  # Use the latest stable version of mypy
     hooks:
       - id: mypy
+        args: ["--allow-subclassing-any"]
         # args: [--ignore-missing-imports]  # Optional: customize your mypy flags

--- a/custom_components/bms_ble/plugins/basebms.py
+++ b/custom_components/bms_ble/plugins/basebms.py
@@ -411,13 +411,14 @@ class BaseBMS(ABC):
                     await self._send_msg(
                         data, max_size, char or self.uuid_tx(), attempt, inv_wr_mode
                     )
+                    if not wait_for_notify:
+                        return  # write without wait for response selected
                     try:
-                        if wait_for_notify:
-                            await asyncio.wait_for(
-                                self._wait_event(),
-                                BaseBMS._RETRY_TIMEOUT
-                                * min(2**attempt, BaseBMS._MAX_TIMEOUT_FACTOR),
-                            )
+                        await asyncio.wait_for(
+                            self._wait_event(),
+                            BaseBMS._RETRY_TIMEOUT
+                            * min(2**attempt, BaseBMS._MAX_TIMEOUT_FACTOR),
+                        )
                     except TimeoutError:
                         self._log.debug("TX BLE request timed out.")
                         continue  # retry sending data


### PR DESCRIPTION
If "do not wait for reply" is selected, do not define write mode as "success" cannot be determined.