### PR TITLE
Support ANT BMS (legacy BLE protocol)

### DIFF
--- a/custom_components/bms_ble/const.py
+++ b/custom_components/bms_ble/const.py
@@ -12,6 +12,7 @@ from homeassistant.const import (  # noqa: F401  # pylint: disable=unused-import
 
 BMS_TYPES: Final[list[str]] = [
     "abc_bms",
+    "ant_bms_legacy",
     "ant_bms",
     "cbtpwr_bms",
     "cbtpwr_vb_bms",

--- a/custom_components/bms_ble/manifest.json
+++ b/custom_components/bms_ble/manifest.json
@@ -112,7 +112,7 @@
     {
       "local_name": "BS20*",
       "service_uuid": "0000ff00-0000-1000-8000-00805f9b34fb"
-    },    
+    },
     {
       "manufacturer_id": 123,
       "service_uuid": "0000ff00-0000-1000-8000-00805f9b34fb"
@@ -159,7 +159,7 @@
     {
       "local_name": "SP3?B*",
       "service_uuid": "0000fff0-0000-1000-8000-00805f9b34fb"
-    },    
+    },
     {
       "local_name": "SP4?B*",
       "service_uuid": "0000fff0-0000-1000-8000-00805f9b34fb"
@@ -183,7 +183,7 @@
     {
       "local_name": "SP9?B*",
       "service_uuid": "0000fff0-0000-1000-8000-00805f9b34fb"
-    },            
+    },
     {
       "local_name": "CSY*",
       "service_uuid": "0000fff0-0000-1000-8000-00805f9b34fb"
@@ -292,6 +292,11 @@
       "local_name": "ANT-BLE*",
       "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb",
       "manufacturer_id": 8979
+    },
+    {
+      "local_name": "ANT-BLE*",
+      "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb",
+      "manufacturer_id": 1623
     },
     {
       "local_name": "RNG*",

--- a/custom_components/bms_ble/plugins/ant_bms_legacy.py
+++ b/custom_components/bms_ble/plugins/ant_bms_legacy.py
@@ -1,0 +1,154 @@
+"""Module to support ANT BMS."""
+
+from enum import IntEnum
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.uuids import normalize_uuid_str
+
+from .basebms import AdvertisementPattern, BaseBMS, BMSdp, BMSsample, BMSvalue, crc_sum
+
+
+class BMS(BaseBMS):
+    """ANT BMS (legacy) implementation."""
+
+    class CMD(IntEnum):
+        """Command codes for ANT BMS."""
+
+        GET = 0xDB
+        SET = 0xA5
+
+    class ADR(IntEnum):
+        """Address codes for ANT BMS."""
+
+        STATUS = 0x00
+
+    _RX_HEADER: Final[bytes] = b"\xaa\x55\xaa"
+
+    _RSP_STAT: Final[int] = 0xFF
+    _RX_HEADER_RSP_STAT: Final[bytes] = b"\xaa\x55\xaa\xff"
+    _RSP_STAT_LEN: Final[int] = 140
+
+    _FIELDS: Final[tuple[BMSdp, ...]] = (
+        BMSdp("voltage", 4, 2, False, lambda x: x / 10),
+        BMSdp("current", 70, 4, True, lambda x: x / -10),
+        BMSdp("battery_level", 74, 1, False),
+        BMSdp("design_capacity", 75, 4, False, lambda x: x // 1e6),
+        BMSdp(
+            "cycle_charge", 79, 4, False, lambda x: x // 1e6
+        ),  # charge remaining [Ah]
+        BMSdp(
+            "total_cycled_charge", 83, 4, False, lambda x: x // 1e3
+        ),  # total cycled charge [Ah]
+        BMSdp("runtime", 87, 4, False),
+        BMSdp("cell_high_voltage", 116, 2, False, lambda x: x / 1000),
+        BMSdp("cell_low_voltage", 119, 2, False, lambda x: x / 1000),
+        BMSdp("cell_count", 123, 1, False),
+    )
+
+    def __init__(self, ble_device: BLEDevice, reconnect: bool = False) -> None:
+        """Initialize BMS."""
+        super().__init__(ble_device, reconnect)
+        self._exp_len = BMS._RSP_STAT_LEN
+
+    @staticmethod
+    def matcher_dict_list() -> list[AdvertisementPattern]:
+        """Provide BluetoothMatcher definition."""
+        return [
+            {
+                "local_name": "ANT-BLE*",
+                "service_uuid": BMS.uuid_services()[0],
+                "manufacturer_id": 1623,
+                "connectable": True,
+            }
+        ]
+
+    @staticmethod
+    def device_info() -> dict[str, str]:
+        """Return device information for the battery management system."""
+        return {"manufacturer": "ANT", "model": "Smart BMS"}
+
+    @staticmethod
+    def uuid_services() -> list[str]:
+        """Return list of 128-bit UUIDs of services required by BMS."""
+        return [normalize_uuid_str("ffe0")]  # change service UUID here!
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """Return 16-bit UUID of characteristic that provides notification/read property."""
+        return "ffe1"
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """Return 16-bit UUID of characteristic that provides write property."""
+        return "ffe1"
+
+    @staticmethod
+    def _calc_values() -> frozenset[BMSvalue]:
+        return frozenset(
+            {"battery_charging", "power"}
+        )  # calculate further values from BMS provided set ones
+
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle the RX characteristics notify event (new data arrives)."""
+
+        if data.startswith(BMS._RX_HEADER_RSP_STAT):
+            self._data = bytearray()
+            self._exp_len = BMS._RSP_STAT_LEN
+
+        _data = self._data
+        _data += data
+        self._log.debug("RX BLE data: %s", data)
+
+        if len(_data) < self._exp_len:
+            return
+
+        remote_crc = _data[-1] | (_data[-2] << 8)
+        if (crc := crc_sum(_data[4:-2], 2)) != remote_crc:
+            self._log.debug("invalid checksum 0x%X != 0x%X", crc, remote_crc)
+            return
+
+        self._data_event.set()
+
+    @staticmethod
+    def _cmd(cmd: CMD, adr: ADR, value: int = 0x0000) -> bytes:
+        """Assemble a ANT BMS command."""
+        value_hi = (value >> 8) & 0xFF
+        value_lo = value & 0xFF
+        return bytes(
+            (cmd, cmd, adr, value_hi, value_lo, (adr + value_hi + value_lo) & 0xFF)
+        )
+
+    async def _async_update(self) -> BMSsample:
+        """Update battery status information."""
+        await self._await_reply(BMS._cmd(BMS.CMD.GET, BMS.ADR.STATUS))
+
+        _data = self._data
+
+        result = BMS._decode_data(
+            BMS._FIELDS,
+            _data,
+            byteorder="big",
+            offset=0,
+        )
+        result["cell_voltages"] = [
+            int.from_bytes(_data[offset : offset + 2], byteorder="big") / 1000
+            for offset in range(6, 6 + result["cell_count"] * 2, 2)
+        ]
+        result["cycles"] = result.get("total_cycled_charge", 0) // (
+            result.get("design_capacity") or 1
+        )
+        result["delta_voltage"] = (
+            result["cell_high_voltage"] - result["cell_low_voltage"]
+        )
+        result["temp_sensors"] = 6
+        result["temp_values"] = [
+            int.from_bytes(_data[offset : offset + 2], byteorder="big")
+            for offset in range(91, 103, 2)
+        ]
+        result["temperature"] = result["temp_values"][0]
+
+        return result


### PR DESCRIPTION
This PR addresses an issue I'm having with an ANT BMS.
After searching the net I've seen through https://github.com/syssi/esphome-ant-bms that it looks like there are 2 versions of these devices at least on the protocol/software side and the 'legacy' one is nicely managed in the repository (the `*_old_ble` source files)

By using the advertised data of my ANT BMS I've come around a slightly different matcher with the following keys:

```yaml    
{
  "local_name": "ANT-BLE*",
  "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb",
  "manufacturer_id": 1623
},
```
where, as can be seen, the difference with respect to the actual ANT matcher lies in the `manufacturer_id` key
I hope this is enough to cover any other ANT implementing this protocol but we'll see...

I've checked ruff and mypy on the code but I'm still in a 'draft' stage at the moment (missing tests for sure)
This early submission is to make you aware I'm working on this and I'd like to discuss some adjustments regarding the BaseBMS model.
More specifically, I've added some custom keys to the `_FIELDS` definitions in order to leverage the automatic parse of the frame done by `BaseBMS._decode_data` but these keys are not defined in the `BMSsample` TypedDict (hence mypy complaining).

If these keys prove to not be relevant in the overall integration architecture I'd quickly cleanup the `_FIELDS` and do the `int.from_bytes` locally in the custom plugin.

The keys I'm talking about are:
- cell_high_voltage
- cell_low_voltage
- total_cycled_charge

I think the `cell_high_voltage` and `cell_low_voltage` could be interesting for the general architecture. They're related to `delta_voltage` but providing those two would give more insights about the cells without the need to expose the full array of cells (See https://github.com/patman15/BMS_BLE-HA/issues/441)

The `total_cycled_charge` instead is a somewhat duplicate of `cycles`. It carries the total amount of charge exchanged by the battery/bms in its life and it is then related to cycles with:
```
cycles = total_cycled_charge / design_capacity
```

If you like them we could better define these new key names or, if not, as stated, I'll just drop them from the _FIELDS and use them only in internal decoding.
