### PR TITLE
Update RoyPow BMS to support PowerUrus manufacturer

### DIFF
--- a/custom_components/bms_ble/manifest.json
+++ b/custom_components/bms_ble/manifest.json
@@ -251,6 +251,10 @@
       "manufacturer_id": 35579
     },
     {
+      "service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb",
+      "manufacturer_id": 49386
+    },
+    {
       "service_uuid": "0000ffd0-0000-1000-8000-00805f9b34fb",
       "manufacturer_id": 39008
     }

--- a/custom_components/bms_ble/plugins/roypow_bms.py
+++ b/custom_components/bms_ble/plugins/roypow_bms.py
@@ -60,7 +60,7 @@ class BMS(BaseBMS):
                 "manufacturer_id": manufacturer_id,
                 "connectable": True,
             }
-            for manufacturer_id in (0x01A8, 0x0B31, 0x8AFB)
+            for manufacturer_id in (0x01A8, 0x0B31, 0x8AFB, 0xC0EA)
         ]
 
     @staticmethod


### PR DESCRIPTION
This PR adds support for PowerUrus batteries which use RoyPow's BMS under the hood. All this required was adding a new manufacturer ID to the existing RoyPow BMS code. 

The battery I tested this with can be found [here](https://powerurus.com/products/powerurus-12v-200ah-lifepo4-deep-cycle-rechargeable-battery?variant=44038483116257). 

The battery uses the RoyPow app so I figured it wouldn't be hard to add support for this battery and thankfully due to the nice modular design of this repo it wasn't! :D

I tested this by installing my fork on my home assistant server and it worked like a charm!