### PR TITLE
Revert normalize MAC address (#576)

### DIFF
--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -53,7 +53,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Check if device is supported by an available BMS class."""
         if not (
             bms_class := await bms_identify(
-                discovery_info.advertisement, format_mac(discovery_info.address)
+                discovery_info.advertisement, discovery_info.address
             )
         ):
             return None
@@ -71,7 +71,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by Bluetooth discovery."""
         LOGGER.debug("Bluetooth device detected: %s", discovery_info)
 
-        address: Final[str] = format_mac(discovery_info.address)
+        address: Final[str] = discovery_info.address
         await self.async_set_unique_id(address)
         self._abort_if_unique_id_configured()
 
@@ -117,7 +117,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         if user_input is not None:
-            address: str = format_mac(user_input[CONF_ADDRESS])
+            address: str = str(user_input[CONF_ADDRESS])
             await self.async_set_unique_id(address, raise_on_progress=False)
             self._abort_if_unique_id_configured()
             self._disc_dev = self._disc_devs[address]
@@ -127,13 +127,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data={"type": self._disc_dev.type},
             )
 
-        current_addresses: Final[set[str | None]] = self._async_current_ids(
-            include_ignore=False
-        )
-        for discovery_info in async_discovered_service_info(
-            self.hass, connectable=True
-        ):
-            address = format_mac(discovery_info.address)
+        current_addresses: Final[set[str | None]] = self._async_current_ids(include_ignore=False)
+        for discovery_info in async_discovered_service_info(self.hass, connectable=True):
+            address = discovery_info.address
             if address in current_addresses or address in self._disc_devs:
                 continue
             if not (bms_module := await self._async_device_supported(discovery_info)):

--- a/custom_components/bms_ble/manifest.json
+++ b/custom_components/bms_ble/manifest.json
@@ -104,5 +104,5 @@
   "loggers": ["bleak_retry_connector", "aiobmsble"],
   "quality_scale": "silver",
   "requirements": ["aiobmsble==0.15.0"],
-  "version": "2.5.0"
+  "version": "2.5.1"
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -26,7 +26,6 @@ from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import format_mac
 
 from .bluetooth import generate_ble_device, inject_bluetooth_service_info_bleak
 from .conftest import (
@@ -82,9 +81,7 @@ async def test_bluetooth_discovery(
     )
     result: ConfigFlowResult = flowresults[0]
     assert result.get("step_id") == "bluetooth_confirm"
-    assert result.get("context", {}).get("unique_id") == format_mac(
-        advertisement.address
-    )
+    assert result.get("context", {}).get("unique_id") == advertisement.address
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"not": "empty"}


### PR DESCRIPTION
format_mac() does not work as the internal dictionary index is fed by bleak which uses captital letter formatted MAC addresses-