### PR TITLE
Add support for nordström battery (SBF)

### DIFF
--- a/custom_components/bms_ble/manifest.json
+++ b/custom_components/bms_ble/manifest.json
@@ -27,6 +27,9 @@
       "local_name": "LT-*"
     },
     {
+      "local_name": "N-?????BL*"
+    },
+    {
       "local_name": "PC-????"
     },
     {


### PR DESCRIPTION
I have a 100Ah Nordström Lithium Bluetooth L5 which seems to just be using some kind of clone or just simply uses a jdb bms. 
I have created this PR in the aiobmsble repo https://github.com/patman15/aiobmsble/pull/169
