### PR TITLE
Add keep_alive option to BMS connection settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 #custom_components/bms_ble/plugins/dummy_bms.py
 TODO.md
 
+# macOS
+.DS_Store

--- a/custom_components/bms_ble/__init__.py
+++ b/custom_components/bms_ble/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.importlib import async_import_module
 
 from .config_flow import ConfigFlow
-from .const import DOMAIN, LOGGER
+from .const import CONF_KEEP_ALIVE, DOMAIN, LOGGER
 from .coordinator import BTBmsCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -55,7 +55,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: BTBmsConfigEntry) -> boo
     coordinator = BTBmsCoordinator(
         hass,
         ble_device,
-        plugin.BMS(ble_device, secret=entry.options.get(CONF_PASSWORD, "")),
+        plugin.BMS(
+            ble_device,
+            keep_alive=entry.options.get(CONF_KEEP_ALIVE, True),
+            secret=entry.options.get(CONF_PASSWORD, ""),
+        ),
         entry,
     )
 

--- a/custom_components/bms_ble/__init__.py
+++ b/custom_components/bms_ble/__init__.py
@@ -133,7 +133,7 @@ async def async_migrate_entry(
         entry_version = EntryVersion(1, 0)
 
     if entry_version.major < 2:
-        new_data["type"] = f"aiobmsble.bms.{new_data["type"].rsplit('.', 1)[-1]}"
+        new_data["type"] = f"aiobmsble.bms.{new_data['type'].rsplit('.', 1)[-1]}"
         entry_version = EntryVersion(2, 0)
 
     if config_entry.version < 3:
@@ -170,7 +170,7 @@ def migrate_sensor_entities(
         unique_id: str = entry.unique_id
         # update entries from wrong old format using no domain prefix
         if not entry.unique_id.startswith(f"{DOMAIN}-"):
-            unique_id = f"{DOMAIN}-{format_mac(config_entry.unique_id)}-{unique_id.split('-')[-1]}"
+            unique_id = f"{DOMAIN}-{format_mac(config_entry.unique_id)}-{unique_id.rsplit('-', maxsplit=1)[-1]}"
         # rename delta_voltage sensor to be consistent with min/max cell voltage sensor
         if unique_id.endswith("-delta_voltage"):
             unique_id = unique_id.removesuffix("-delta_voltage") + "-delta_cell_voltage"

--- a/custom_components/bms_ble/__init__.py
+++ b/custom_components/bms_ble/__init__.py
@@ -133,7 +133,7 @@ async def async_migrate_entry(
         entry_version = EntryVersion(1, 0)
 
     if entry_version.major < 2:
-        new_data["type"] = f"aiobmsble.bms.{new_data['type'].rsplit('.', 1)[-1]}"
+        new_data["type"] = f"aiobmsble.bms.{new_data["type"].rsplit('.', 1)[-1]}"
         entry_version = EntryVersion(2, 0)
 
     if config_entry.version < 3:

--- a/custom_components/bms_ble/__init__.py
+++ b/custom_components/bms_ble/__init__.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Final
+from typing import Any, Final
 
 from bleak.backends.device import BLEDevice
 
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.importlib import async_import_module
 
 from .config_flow import ConfigFlow
-from .const import CONF_KEEP_ALIVE, DOMAIN, LOGGER
+from .const import CONF_ADVANCED_OPTIONS, CONF_KEEP_ALIVE, DOMAIN, LOGGER
 from .coordinator import BTBmsCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -52,12 +52,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: BTBmsConfigEntry) -> boo
         )
 
     plugin: ModuleType = await async_import_module(hass, entry.data["type"])
+    advanced_options: dict[str, Any] = entry.options.get(CONF_ADVANCED_OPTIONS, {})
     coordinator = BTBmsCoordinator(
         hass,
         ble_device,
         plugin.BMS(
             ble_device,
-            keep_alive=entry.options.get(CONF_KEEP_ALIVE, True),
+            keep_alive=advanced_options.get(CONF_KEEP_ALIVE, True),
             secret=entry.options.get(CONF_PASSWORD, ""),
         ),
         entry,

--- a/custom_components/bms_ble/binary_sensor.py
+++ b/custom_components/bms_ble/binary_sensor.py
@@ -42,7 +42,11 @@ class BmsBinaryEntityDescription(BinarySensorEntityDescription, frozen_or_thawed
 BINARY_SENSOR_TYPES: list[BmsBinaryEntityDescription] = [
     BmsBinaryEntityDescription(
         attr_fn=lambda data: (
-            {ATTR_BATTERY_MODE: data.get(ATTR_BATTERY_MODE, BMSMode.UNKNOWN).name.lower()}
+            {
+                ATTR_BATTERY_MODE: data.get(
+                    ATTR_BATTERY_MODE, BMSMode.UNKNOWN
+                ).name.lower()
+            }
             if ATTR_BATTERY_MODE in data
             else {}
         ),

--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -35,7 +36,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import DOMAIN, LOGGER
+from .const import CONF_KEEP_ALIVE, DOMAIN, LOGGER
 
 
 @dataclass
@@ -210,25 +211,19 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         )
         if not bms_class:
             return self.async_abort(reason="not_supported")
-        if not bms_class.accept_secret:
-            LOGGER.debug("No options for %s", bms_class.bms_id())
-            return self.async_abort(
-                reason="device_has_no_options",
-                description_placeholders={"model": bms_class.bms_id()},
+        schema_dict: dict = {
+            vol.Optional(CONF_KEEP_ALIVE, default=True): BooleanSelector(),
+        }
+
+        if bms_class.accept_secret:
+            schema_dict[vol.Optional(CONF_PASSWORD)] = TextSelector(
+                TextSelectorConfig(type=TextSelectorType.PASSWORD)
             )
 
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                vol.Schema(
-                    {
-                        vol.Optional(
-                            CONF_PASSWORD,
-                        ): TextSelector(
-                            TextSelectorConfig(type=TextSelectorType.PASSWORD)
-                        ),
-                    }
-                ),
+                vol.Schema(schema_dict),
                 self.config_entry.options,
             ),
         )

--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -212,7 +212,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         if not bms_class:
             return self.async_abort(reason="not_supported")
         schema_dict: dict = {
-            vol.Optional(CONF_KEEP_ALIVE, default=True): BooleanSelector(),
+            vol.Optional(CONF_KEEP_ALIVE, default=True, description={"advanced": True}): BooleanSelector(),
         }
 
         if bms_class.accept_secret:

--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
 )
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     BooleanSelector,
@@ -35,8 +36,9 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.typing import VolDictType
 
-from .const import CONF_KEEP_ALIVE, DOMAIN, LOGGER
+from .const import CONF_ADVANCED_OPTIONS, CONF_KEEP_ALIVE, DOMAIN, LOGGER
 
 
 @dataclass
@@ -218,15 +220,22 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                 description_placeholders={"model": bms_class.bms_id()},
             )
 
-        schema_dict: dict = {}
-
-        if bms_class.accept_secret:
-            schema_dict[vol.Optional(CONF_PASSWORD)] = TextSelector(
-                TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        schema_dict: VolDictType = {
+            vol.Optional(CONF_PASSWORD): TextSelector(
+                TextSelectorConfig(
+                    type=TextSelectorType.PASSWORD,
+                    read_only=not bms_class.accept_secret,
+                )
             )
+        }
 
         if self.show_advanced_options:
-            schema_dict[vol.Optional(CONF_KEEP_ALIVE, default=True)] = BooleanSelector()
+            schema_dict[vol.Optional(CONF_ADVANCED_OPTIONS)] = section(
+                vol.Schema(
+                    {vol.Optional(CONF_KEEP_ALIVE, default=True): BooleanSelector()}
+                ),
+                {"collapsed": True},
+            )
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -211,14 +211,22 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         )
         if not bms_class:
             return self.async_abort(reason="not_supported")
-        schema_dict: dict = {
-            vol.Optional(CONF_KEEP_ALIVE, default=True, description={"advanced": True}): BooleanSelector(),
-        }
+        if not bms_class.accept_secret and not self.show_advanced_options:
+            LOGGER.debug("No options for %s", bms_class.bms_id())
+            return self.async_abort(
+                reason="device_has_no_options",
+                description_placeholders={"model": bms_class.bms_id()},
+            )
+
+        schema_dict: dict = {}
 
         if bms_class.accept_secret:
             schema_dict[vol.Optional(CONF_PASSWORD)] = TextSelector(
                 TextSelectorConfig(type=TextSelectorType.PASSWORD)
             )
+
+        if self.show_advanced_options:
+            schema_dict[vol.Optional(CONF_KEEP_ALIVE, default=True)] = BooleanSelector()
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/bms_ble/const.py
+++ b/custom_components/bms_ble/const.py
@@ -7,6 +7,7 @@ DOMAIN: Final = "bms_ble"
 LOGGER: Final[logging.Logger] = logging.getLogger(__package__)
 LOW_RSSI: Final[int] = -75  # dBm considered low signal strength
 UPDATE_INTERVAL: Final[int] = 30  # [s]
+CONF_KEEP_ALIVE: Final[str] = "keep_alive"
 
 # attributes (do not change)
 ATTR_BALANCER: Final[str] = "balancer"  # [bool]

--- a/custom_components/bms_ble/const.py
+++ b/custom_components/bms_ble/const.py
@@ -8,6 +8,7 @@ LOGGER: Final[logging.Logger] = logging.getLogger(__package__)
 LOW_RSSI: Final[int] = -75  # dBm considered low signal strength
 UPDATE_INTERVAL: Final[int] = 30  # [s]
 CONF_KEEP_ALIVE: Final[str] = "keep_alive"
+CONF_ADVANCED_OPTIONS: Final[str] = "advanced_options"
 
 # attributes (do not change)
 ATTR_BALANCER: Final[str] = "balancer"  # [bool]

--- a/custom_components/bms_ble/strings.json
+++ b/custom_components/bms_ble/strings.json
@@ -91,13 +91,15 @@
     "step": {
       "init": {
         "data": {
-          "password": "Device password"
+          "password": "Device password",
+          "keep_alive": "Keep connection alive between updates"
         },
         "data_description": {
-          "password": "Optional password to unlock device."
+          "password": "Optional password to unlock device.",
+          "keep_alive": "If disabled, the Bluetooth connection is released after each update. Recommended when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations."
         },
         "title": "Connection options"
       }
     }
-  }  
+  }
 }

--- a/custom_components/bms_ble/strings.json
+++ b/custom_components/bms_ble/strings.json
@@ -96,7 +96,7 @@
         },
         "data_description": {
           "password": "Optional password to unlock device.",
-          "keep_alive": "If disabled, the Bluetooth connection is released after each update. Recommended when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations."
+          "keep_alive": "Keep the Bluetooth connection open between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
         },
         "title": "Connection options"
       }

--- a/custom_components/bms_ble/strings.json
+++ b/custom_components/bms_ble/strings.json
@@ -91,14 +91,24 @@
     "step": {
       "init": {
         "data": {
-          "password": "Device password",
-          "keep_alive": "Keep connection alive between updates"
+          "password": "Device password"
         },
         "data_description": {
-          "password": "Optional password to unlock device.",
-          "keep_alive": "Keep the Bluetooth connection open between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+          "password": "Optional password to unlock device."
         },
-        "title": "Connection options"
+        "sections": {
+          "advanced_options": {
+            "data": {
+              "keep_alive": "Keep connection alive between updates"
+            },
+            "data_description": {
+              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+            },
+            "name": "Advanced settings"
+          }
+        },
+        "title": "Connection options",
+        "description": "The password option is only available if supported by the device."
       }
     }
   }

--- a/custom_components/bms_ble/translations/cs.json
+++ b/custom_components/bms_ble/translations/cs.json
@@ -1,0 +1,99 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Zařízení je již nakonfigurováno.",
+      "no_devices_found": "Nebyla nalezena žádná podporovaná zařízení přes Bluetooth.",
+      "not_supported": "Zařízení není podporováno."
+    },
+    "flow_title": "Nastavení {name} ({id}) jako {model}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Chcete nastavit {name} ({id})?"
+      },
+      "user": {
+        "data": {
+          "address": "Název Bluetooth (MAC adresa) - Model"
+        },
+        "description": "Vyberte zařízení k nastavení"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "balancer": {
+        "name": "Vyrovnávač"
+      },
+      "chrg_mosfet": {
+        "name": "MOSFET nabíjení"
+      },
+      "dischrg_mosfet": {
+        "name": "MOSFET vybíjení"
+      },
+      "heater": {
+        "name": "Ohřívač"
+      }
+    },
+    "sensor": {
+      "battery_health": {
+        "name": "Zdraví baterie"
+      },
+      "cycles": {
+        "name": "Cykly"
+      },
+      "delta_cell_voltage": {
+        "name": "Rozdíl napětí článků"
+      },
+      "link_quality": {
+        "name": "Kvalita spojení"
+      },
+      "max_cell_voltage": {
+        "name": "Nejvyšší napětí článku"
+      },
+      "min_cell_voltage": {
+        "name": "Nejnižší napětí článku"
+      },
+      "runtime": {
+        "name": "Doba provozu"
+      }
+    }
+  },
+  "exceptions": {
+    "bms_com_fail": {
+      "message": "Komunikace s BMS selhala: {err_msg}, síla signálu {rssi} dBm."
+    },
+    "bms_com_fail_rssi": {
+      "message": "Komunikace s BMS selhala: {err_msg}. Zkuste zvýšit sílu signálu z {rssi} dBm."
+    },
+    "bms_no_valid_data": {
+      "message": "BMS neposkytlo platná data."
+    },
+    "bms_timeout": {
+      "message": "Komunikace s BMS vypršela."
+    },
+    "device_not_found": {
+      "message": "BMS ({mac}) nebylo nalezeno přes Bluetooth."
+    },
+    "missing_unique_id": {
+      "message": "Chybí jedinečné ID zařízení."
+    }
+  },
+  "options": {
+    "abort": {
+      "device_has_no_options": "Toto zařízení nepodporuje možnosti konfigurace.",
+      "not_supported": "Nepodporovaná konfigurace zařízení."
+    },
+    "step": {
+      "init": {
+        "title": "Možnosti připojení",
+        "data": {
+          "password": "Heslo zařízení",
+          "keep_alive": "Udržovat připojení mezi aktualizacemi"
+        },
+        "data_description": {
+          "password": "Volitelné heslo pro odemčení zařízení.",
+          "keep_alive": "Udržuje Bluetooth připojení otevřené mezi cykly aktualizací. Vypnutí snižuje spolehlivost připojení BMS a doporučuje se pouze jako krajní řešení při sdílení adaptéru s jediným připojením (např. Realtek RTL8761B) s jinými integracemi. Zvažte raději použití dedikovaného Bluetooth adaptéru."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/bms_ble/translations/cs.json
+++ b/custom_components/bms_ble/translations/cs.json
@@ -84,15 +84,25 @@
     },
     "step": {
       "init": {
-        "title": "Možnosti připojení",
         "data": {
-          "password": "Heslo zařízení",
-          "keep_alive": "Udržovat připojení mezi aktualizacemi"
+          "password": "Heslo zařízení"
         },
         "data_description": {
-          "password": "Volitelné heslo pro odemčení zařízení.",
-          "keep_alive": "Udržuje Bluetooth připojení otevřené mezi cykly aktualizací. Vypnutí snižuje spolehlivost připojení BMS a doporučuje se pouze jako krajní řešení při sdílení adaptéru s jediným připojením (např. Realtek RTL8761B) s jinými integracemi. Zvažte raději použití dedikovaného Bluetooth adaptéru."
-        }
+          "password": "Volitelné heslo pro odemčení zařízení."
+        },
+        "sections": {
+          "advanced_options": {
+            "data": {
+              "keep_alive": "Udržovat připojení mezi aktualizacemi"
+            },
+            "data_description": {
+              "keep_alive": "Udržuje Bluetooth připojení otevřené mezi cykly aktualizací. Vypnutí snižuje spolehlivost připojení BMS a doporučuje se pouze jako krajní řešení při sdílení adaptéru s jediným připojením (např. Realtek RTL8761B) s jinými integracemi. Zvažte raději použití dedikovaného Bluetooth adaptéru."
+            },
+            "name": "Pokročilá nastavení"
+          }
+        },
+        "title": "Možnosti připojení",
+        "description": "Možnost zadání hesla je dostupná pouze v případě, že tuto funkcionalitu zařízení podporuje."        
       }
     }
   }

--- a/custom_components/bms_ble/translations/de.json
+++ b/custom_components/bms_ble/translations/de.json
@@ -66,7 +66,7 @@
     },
     "bms_no_valid_data": {
       "message": "Das BMS hat keine gültigen Daten gesendet."
-    },    
+    },
     "bms_timeout": {
       "message": "Zeitüberschreitung bei BMS Kommunikation."
     },
@@ -85,10 +85,12 @@
     "step": {
       "init": {
         "data": {
-          "password": "Gerätepasswort"
+          "password": "Gerätepasswort",
+          "keep_alive": "Verbindung zwischen Updates aufrechterhalten"
         },
         "data_description": {
-          "password": "Optionales Passwort zum Entsperren des Geräts."
+          "password": "Optionales Passwort zum Entsperren des Geräts.",
+          "keep_alive": "Wenn deaktiviert, wird die Bluetooth-Verbindung nach jedem Update getrennt. Empfohlen bei gemeinsamer Nutzung eines Adapters mit nur einer Verbindung (z. B. Realtek RTL8761B) mit anderen Integrationen."
         },
         "title": "Verbindungsoptionen"
       }

--- a/custom_components/bms_ble/translations/de.json
+++ b/custom_components/bms_ble/translations/de.json
@@ -90,7 +90,7 @@
         },
         "data_description": {
           "password": "Optionales Passwort zum Entsperren des Geräts.",
-          "keep_alive": "Wenn deaktiviert, wird die Bluetooth-Verbindung nach jedem Update getrennt. Empfohlen bei gemeinsamer Nutzung eines Adapters mit nur einer Verbindung (z. B. Realtek RTL8761B) mit anderen Integrationen."
+          "keep_alive": "Hält die Bluetooth-Verbindung zwischen den Update-Zyklen offen. Das Deaktivieren verschlechtert die Verbindungszuverlässigkeit des BMS und wird nur als letztes Mittel empfohlen, wenn ein Bluetooth-Adapter mit nur einer Verbindung (z. B. Realtek RTL8761B) mit anderen Integrationen geteilt wird. Verwende nach Möglichkeit einen dedizierten Bluetooth-Adapter."
         },
         "title": "Verbindungsoptionen"
       }

--- a/custom_components/bms_ble/translations/de.json
+++ b/custom_components/bms_ble/translations/de.json
@@ -85,14 +85,24 @@
     "step": {
       "init": {
         "data": {
-          "password": "Gerätepasswort",
-          "keep_alive": "Verbindung zwischen Updates aufrechterhalten"
+          "password": "Gerätepasswort"
         },
         "data_description": {
-          "password": "Optionales Passwort zum Entsperren des Geräts.",
-          "keep_alive": "Hält die Bluetooth-Verbindung zwischen den Update-Zyklen offen. Das Deaktivieren verschlechtert die Verbindungszuverlässigkeit des BMS und wird nur als letztes Mittel empfohlen, wenn ein Bluetooth-Adapter mit nur einer Verbindung (z. B. Realtek RTL8761B) mit anderen Integrationen geteilt wird. Verwende nach Möglichkeit einen dedizierten Bluetooth-Adapter."
+          "password": "Optionales Passwort zum Entsperren des Geräts."
         },
-        "title": "Verbindungsoptionen"
+        "sections": {
+          "advanced_options": {
+            "data": {
+              "keep_alive": "Verbindung zwischen Updates aufrechterhalten"
+            },
+            "data_description": {
+               "keep_alive": "Hält die Bluetooth-Verbindung zwischen den Update-Zyklen. Das Deaktivieren verschlechtert die Verbindungszuverlässigkeit des BMS und wird nur als letztes Mittel empfohlen, wenn ein Bluetooth-Adapter mit nur einer Verbindung (z. B. Realtek RTL8761B) mit anderen Integrationen geteilt wird. Verwende nach Möglichkeit einen dedizierten Bluetooth-Adapter."
+            },
+            "name": "Erweiterte Optionen"
+          }
+        },
+        "title": "Verbindungsoptionen",
+        "description": "Die Passwortoption ist nur verfügbar, wenn vom Gerät unterstützt."
       }
     }
   }

--- a/custom_components/bms_ble/translations/en.json
+++ b/custom_components/bms_ble/translations/en.json
@@ -90,7 +90,7 @@
         },
         "data_description": {
           "password": "Optional password to unlock device.",
-          "keep_alive": "If disabled, the Bluetooth connection is released after each update. Recommended when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations."
+          "keep_alive": "Keep the Bluetooth connection open between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
         },
         "title": "Connection options"
       }

--- a/custom_components/bms_ble/translations/en.json
+++ b/custom_components/bms_ble/translations/en.json
@@ -85,10 +85,12 @@
     "step": {
       "init": {
         "data": {
-          "password": "Device password"
+          "password": "Device password",
+          "keep_alive": "Keep connection alive between updates"
         },
         "data_description": {
-          "password": "Optional password to unlock device."
+          "password": "Optional password to unlock device.",
+          "keep_alive": "If disabled, the Bluetooth connection is released after each update. Recommended when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations."
         },
         "title": "Connection options"
       }

--- a/custom_components/bms_ble/translations/en.json
+++ b/custom_components/bms_ble/translations/en.json
@@ -85,14 +85,24 @@
     "step": {
       "init": {
         "data": {
-          "password": "Device password",
-          "keep_alive": "Keep connection alive between updates"
+          "password": "Device password"
         },
         "data_description": {
-          "password": "Optional password to unlock device.",
-          "keep_alive": "Keep the Bluetooth connection open between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+          "password": "Optional password to unlock device."
         },
-        "title": "Connection options"
+        "sections": {
+          "advanced_options": {
+            "data": {
+              "keep_alive": "Keep connection alive between updates"
+            },
+            "data_description": {
+              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+            },
+            "name": "Advanced options"
+          }
+        },
+        "title": "Connection options",
+        "description": "The password option is only available if supported by the device."
       }
     }
   }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -482,7 +482,9 @@ async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
 
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
-    assert "keep_alive" in result["data_schema"].schema
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    assert "keep_alive" in data_schema.schema
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -78,9 +78,9 @@ async def test_bluetooth_discovery(
     flowresults: list[ConfigFlowResult] = (
         hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     )
-    assert (
-        len(flowresults) == 1
-    ), f"Expected one flow result for {advertisement}, check manifest.json!"
+    assert len(flowresults) == 1, (
+        f"Expected one flow result for {advertisement}, check manifest.json!"
+    )
     result: ConfigFlowResult = flowresults[0]
     assert result.get("step_id") == "bluetooth_confirm"
     assert result.get("context", {}).get("unique_id") == advertisement.address

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -447,11 +447,10 @@ async def test_options_flow(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-@pytest.mark.parametrize("bms_type", ["dummy_bms", "invalid_bms"])
-async def test_invalid_options_flow(hass: HomeAssistant, bms_type: str) -> None:
-    """Test config options flow."""
+async def test_invalid_options_flow(hass: HomeAssistant) -> None:
+    """Test config options flow for unsupported BMS type."""
 
-    cfg: MockConfigEntry = mock_config(bms=bms_type)
+    cfg: MockConfigEntry = mock_config(bms="invalid_bms")
     cfg.add_to_hass(hass)
 
     await hass.config_entries.async_setup(cfg.entry_id)
@@ -462,11 +461,26 @@ async def test_invalid_options_flow(hass: HomeAssistant, bms_type: str) -> None:
     )
 
     assert result.get("type") is FlowResultType.ABORT
-    assert (
-        result.get("reason") == "device_has_no_options"
-        if bms_type == "dummy_bms"
-        else "not_supported"
+    assert result.get("reason") == "not_supported"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
+    """Test options flow for BMS without secret shows keep_alive toggle."""
+
+    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
+    cfg.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(cfg.entry_id)
+    await hass.async_block_till_done()
+
+    result: ConfigFlowResult = await hass.config_entries.options.async_init(
+        cfg.entry_id
     )
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "init"
+    assert "keep_alive" in result["data_schema"].schema
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,6 +12,7 @@ from voluptuous import Schema
 from custom_components.bms_ble.config_flow import ConfigFlow
 from custom_components.bms_ble.const import (
     BINARY_SENSORS,
+    CONF_KEEP_ALIVE,
     DOMAIN,
     LINK_SENSORS,
     SENSORS,
@@ -436,13 +437,14 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_PASSWORD: "123456"},
+        user_input={CONF_PASSWORD: "123456", CONF_KEEP_ALIVE: True},
     )
     await hass.async_block_till_done()
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert cfg.options == {
         CONF_PASSWORD: "123456",
+        CONF_KEEP_ALIVE: True,
     }
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from homeassistant.helpers import entity_registry as er
 
 from .bluetooth import generate_ble_device, inject_bluetooth_service_info_bleak
@@ -303,7 +303,7 @@ async def test_async_setup_entry(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_setup_entry_missing_unique_id(bms_fixture, hass: HomeAssistant) -> None:
+async def test_setup_entry_missing_unique_id(bms_fixture: str, hass: HomeAssistant) -> None:
     """Test async_setup_entry with missing unique id."""
 
     cfg: MockConfigEntry = mock_config(bms=bms_fixture, unique_id=None)
@@ -453,16 +453,11 @@ async def test_options_flow(
 
 @pytest.mark.usefixtures("enable_bluetooth")
 @pytest.mark.parametrize("show_adv_opt", [True, False], ids=["adv_opt", "no_adv_opt"])
-async def test_options_flow_no_secret(
-    monkeypatch: pytest.MonkeyPatch, hass: HomeAssistant, show_adv_opt: bool
-) -> None:
+async def test_options_flow_no_secret(hass: HomeAssistant, show_adv_opt: bool) -> None:
     """Test if options flow for BMS without secret and disabled advanced mode."""
 
-    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
+    cfg: MockConfigEntry = mock_config()
     cfg.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(cfg.entry_id)
-    await hass.async_block_till_done()
 
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
         cfg.entry_id, context={"show_advanced_options": show_adv_opt}
@@ -475,11 +470,6 @@ async def test_options_flow_no_secret(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
 
-    monkeypatch.setattr(
-        "custom_components.bms_ble.async_setup_entry",
-        lambda hass, entry: True,
-    )
-
     OPTIONS: Final[dict[str, Any]] = {CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: True}}
 
     result = await hass.config_entries.options.async_configure(
@@ -489,6 +479,71 @@ async def test_options_flow_no_secret(
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert cfg.options == OPTIONS
+
+
+@pytest.mark.usefixtures("enable_bluetooth", "patch_default_bleak_client")
+@pytest.mark.parametrize("keep_alive", [True, False])
+async def test_options_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant,
+    bt_discovery: BluetoothServiceInfoBleak,
+    keep_alive: bool,
+) -> None:
+    """Test if options settings reach BMS class."""
+
+    options: dict[str, Any] = {}
+
+    def mock_bms_init(
+        _self,
+        ble_device: Any,
+        keep_alive: bool = True,
+        secret: str = "",
+        logger_name: str = "",
+    ) -> None:
+        options[CONF_KEEP_ALIVE] = keep_alive
+        options[CONF_PASSWORD] = secret
+
+    inject_bluetooth_service_info_bleak(hass, bt_discovery)
+
+    cfg: MockConfigEntry = mock_config()
+    cfg.add_to_hass(hass)
+
+    bms_module: Final[str] = "aiobmsble.bms.dummy_bms"
+    monkeypatch.setattr(f"{bms_module}.BMS.__init__", mock_bms_init)
+    monkeypatch.setattr(f"{bms_module}.BMS.device_info", mock_devinfo_min)
+    monkeypatch.setattr(f"{bms_module}.BMS.async_update", mock_update_min)
+
+    await hass.async_block_till_done()
+
+    result: ConfigFlowResult = await hass.config_entries.options.async_init(
+        cfg.entry_id, context={"show_advanced_options": True}
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "init"
+
+    # check options flow enforces schema
+    with pytest.raises(InvalidData):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"invalid": "option"}
+        )
+
+    OPTIONS: dict[str, Any] = {
+        CONF_PASSWORD: "123abc",
+        CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: keep_alive},
+    }
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=OPTIONS
+    )
+    await hass.async_block_till_done()
+
+    assert cfg in hass.config_entries.async_entries()
+    assert cfg.state is ConfigEntryState.LOADED
+    assert cfg.options == OPTIONS
+    assert (
+        options[CONF_KEEP_ALIVE] == keep_alive
+    ), f"keep_alive value {keep_alive} not set."
+    assert options.get(CONF_PASSWORD) == "123abc"
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -424,7 +424,7 @@ async def test_options_flow(
     await hass.async_block_till_done()
 
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
-        cfg.entry_id
+        cfg.entry_id, context={"show_advanced_options": True}
     )
 
     assert result.get("type") is FlowResultType.FORM
@@ -477,7 +477,7 @@ async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
-        cfg.entry_id
+        cfg.entry_id, context={"show_advanced_options": True}
     )
 
     assert result.get("type") is FlowResultType.FORM

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -468,20 +468,26 @@ async def test_invalid_options_flow(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("enable_bluetooth")
 async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
-    """Test options flow for BMS without secret shows keep_alive toggle."""
-
+    """Test options flow for BMS without secret aborts without advanced mode."""
     cfg: MockConfigEntry = mock_config(bms="dummy_bms")
     cfg.add_to_hass(hass)
-
     await hass.config_entries.async_setup(cfg.entry_id)
     await hass.async_block_till_done()
-
+    # Without advanced mode: abort
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
+        cfg.entry_id
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "device_has_no_options"
+    # With advanced mode: show keep_alive toggle
+    result = await hass.config_entries.options.async_init(
         cfg.entry_id, context={"show_advanced_options": True}
     )
-
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    assert "keep_alive" in data_schema.schema
     data_schema = result.get("data_schema")
     assert data_schema is not None
     assert "keep_alive" in data_schema.schema

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -447,6 +447,24 @@ async def test_options_flow(
         CONF_KEEP_ALIVE: True,
     }
 
+@pytest.mark.usefixtures("enable_bluetooth")
+async def test_options_flow_no_advanced_mode(hass: HomeAssistant) -> None:
+    """Test options flow without advanced mode hides keep_alive for BMS with secret."""
+    cfg: MockConfigEntry = mock_config(bms="jbd_bms")
+    cfg.add_to_hass(hass)
+    await hass.config_entries.async_setup(cfg.entry_id)
+    await hass.async_block_till_done()
+    result: ConfigFlowResult = await hass.config_entries.options.async_init(
+        cfg.entry_id
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "init"
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    assert CONF_PASSWORD in [str(k) for k in data_schema.schema]
+    assert CONF_KEEP_ALIVE not in [str(k) for k in data_schema.schema]
+
+
 
 @pytest.mark.usefixtures("enable_bluetooth")
 async def test_invalid_options_flow(hass: HomeAssistant) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -529,12 +529,10 @@ async def test_no_migration(bms_fixture: str, hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_migrate_entry_future_version(
-    bms_fixture: str, hass: HomeAssistant
-) -> None:
+async def test_migrate_entry_future_version(hass: HomeAssistant) -> None:
     """Test migrating entries from future version."""
 
-    cfg: MockConfigEntry = mock_config(bms=bms_fixture)
+    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
     cfg.add_to_hass(hass)
     hass.config_entries.async_update_entry(cfg, version=999)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the BLE Battery Management System integration config flow."""
 
-from typing import Final
+from typing import Any, Final
 
 from aiobmsble.test_data import bms_advertisements
 from bleak.backends.scanner import AdvertisementData
@@ -12,6 +12,7 @@ from voluptuous import Schema
 from custom_components.bms_ble.config_flow import ConfigFlow
 from custom_components.bms_ble.const import (
     BINARY_SENSORS,
+    CONF_ADVANCED_OPTIONS,
     CONF_KEEP_ALIVE,
     DOMAIN,
     LINK_SENSORS,
@@ -79,9 +80,9 @@ async def test_bluetooth_discovery(
     flowresults: list[ConfigFlowResult] = (
         hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     )
-    assert len(flowresults) == 1, (
-        f"Expected one flow result for {advertisement}, check manifest.json!"
-    )
+    assert (
+        len(flowresults) == 1
+    ), f"Expected one flow result for {advertisement}, check manifest.json!"
     result: ConfigFlowResult = flowresults[0]
     assert result.get("step_id") == "bluetooth_confirm"
     assert result.get("context", {}).get("unique_id") == advertisement.address
@@ -411,12 +412,17 @@ async def test_user_setup_double_configure(
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.parametrize("show_adv_opt", [True, False], ids=["adv_opt", "no_adv_opt"])
 async def test_options_flow(
-    monkeypatch: pytest.MonkeyPatch, hass: HomeAssistant
+    monkeypatch: pytest.MonkeyPatch, hass: HomeAssistant, show_adv_opt: bool
 ) -> None:
     """Test config options flow."""
 
-    # pick one type with password option
+    OPTIONS: Final[dict[str, Any]] = {CONF_PASSWORD: "123456"} | (
+        {CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: True}} if show_adv_opt else {}
+    )
+
+    # pick one BMS type with password option
     cfg: MockConfigEntry = mock_config(bms="jbd_bms")
     cfg.add_to_hass(hass)
 
@@ -424,7 +430,7 @@ async def test_options_flow(
     await hass.async_block_till_done()
 
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
-        cfg.entry_id, context={"show_advanced_options": True}
+        cfg.entry_id, context={"show_advanced_options": show_adv_opt}
     )
 
     assert result.get("type") is FlowResultType.FORM
@@ -437,33 +443,52 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_PASSWORD: "123456", CONF_KEEP_ALIVE: True},
+        user_input=OPTIONS,
     )
     await hass.async_block_till_done()
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
-    assert cfg.options == {
-        CONF_PASSWORD: "123456",
-        CONF_KEEP_ALIVE: True,
-    }
+    assert cfg.options == OPTIONS
+
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_options_flow_no_advanced_mode(hass: HomeAssistant) -> None:
-    """Test options flow without advanced mode hides keep_alive for BMS with secret."""
-    cfg: MockConfigEntry = mock_config(bms="jbd_bms")
+@pytest.mark.parametrize("show_adv_opt", [True, False], ids=["adv_opt", "no_adv_opt"])
+async def test_options_flow_no_secret(
+    monkeypatch: pytest.MonkeyPatch, hass: HomeAssistant, show_adv_opt: bool
+) -> None:
+    """Test if options flow for BMS without secret and disabled advanced mode."""
+
+    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
     cfg.add_to_hass(hass)
+
     await hass.config_entries.async_setup(cfg.entry_id)
     await hass.async_block_till_done()
+
     result: ConfigFlowResult = await hass.config_entries.options.async_init(
-        cfg.entry_id
+        cfg.entry_id, context={"show_advanced_options": show_adv_opt}
     )
+    if not show_adv_opt:  # Abort without advanced mode
+        assert result.get("type") is FlowResultType.ABORT
+        assert result.get("reason") == "device_has_no_options"
+        return
+
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
-    data_schema = result.get("data_schema")
-    assert data_schema is not None
-    assert CONF_PASSWORD in [str(k) for k in data_schema.schema]
-    assert CONF_KEEP_ALIVE not in [str(k) for k in data_schema.schema]
 
+    monkeypatch.setattr(
+        "custom_components.bms_ble.async_setup_entry",
+        lambda hass, entry: True,
+    )
+
+    OPTIONS: Final[dict[str, Any]] = {CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: True}}
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=OPTIONS
+    )
+    await hass.async_block_till_done()
+
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert cfg.options == OPTIONS
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -482,33 +507,6 @@ async def test_invalid_options_flow(hass: HomeAssistant) -> None:
 
     assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "not_supported"
-
-
-@pytest.mark.usefixtures("enable_bluetooth")
-async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
-    """Test options flow for BMS without secret aborts without advanced mode."""
-    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
-    cfg.add_to_hass(hass)
-    await hass.config_entries.async_setup(cfg.entry_id)
-    await hass.async_block_till_done()
-    # Without advanced mode: abort
-    result: ConfigFlowResult = await hass.config_entries.options.async_init(
-        cfg.entry_id
-    )
-    assert result.get("type") is FlowResultType.ABORT
-    assert result.get("reason") == "device_has_no_options"
-    # With advanced mode: show keep_alive toggle
-    result = await hass.config_entries.options.async_init(
-        cfg.entry_id, context={"show_advanced_options": True}
-    )
-    assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "init"
-    data_schema = result.get("data_schema")
-    assert data_schema is not None
-    assert "keep_alive" in data_schema.schema
-    data_schema = result.get("data_schema")
-    assert data_schema is not None
-    assert "keep_alive" in data_schema.schema
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -46,23 +46,23 @@ async def test_init_fail(
     cfg: MockConfigEntry = mock_config(bms=bms_fixture)
     cfg.add_to_hass(hass)
 
-    assert not await hass.config_entries.async_setup(
-        cfg.entry_id
-    ), "test did not make setup fail!"
+    assert not await hass.config_entries.async_setup(cfg.entry_id), (
+        "test did not make setup fail!"
+    )
     await hass.async_block_till_done()
 
     # verify it is not yet loaded
     assert cfg.state is ConfigEntryState.SETUP_RETRY
 
     assert trace_fct["stop_called"] is True, "Failed to call coordinator stop()."
-    assert (
-        cfg in hass.config_entries.async_entries()
-    ), "Incorrect configuration entry found."
+    assert cfg in hass.config_entries.async_entries(), (
+        "Incorrect configuration entry found."
+    )
     # Assert platforms unloaded
     await hass.async_block_till_done()
-    assert (
-        len(hass.states.async_all(["sensor", "binary_sensor"])) == 0
-    ), "Failure: config entry generated sensors."
+    assert len(hass.states.async_all(["sensor", "binary_sensor"])) == 0, (
+        "Failure: config entry generated sensors."
+    )
 
 
 @pytest.mark.usefixtures("enable_bluetooth", "patch_default_bleak_client")
@@ -118,10 +118,10 @@ async def test_unload_entry(
     assert (  # shutdown is only called if entry unload succeeded
         trace_fct["shutdown_called"] or unload_fail
     ), "Failed to call coordinator async_shutdown()."
-    assert (
-        cfg not in hass.config_entries.async_entries()
-    ), "Failed to remove configuration entry."
+    assert cfg not in hass.config_entries.async_entries(), (
+        "Failed to remove configuration entry."
+    )
     # Assert platforms unloaded
-    assert (
-        len(hass.states.async_all(["sensor", "binary_sensor"])) == 0
-    ), "Failed to remove platforms."
+    assert len(hass.states.async_all(["sensor", "binary_sensor"])) == 0, (
+        "Failed to remove platforms."
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,14 +17,13 @@ from .conftest import mock_config, mock_devinfo_min, mock_exception, mock_update
 @pytest.mark.parametrize("swap", [False, True], ids=["devinfo", "update"])
 async def test_init_fail(
     monkeypatch: pytest.MonkeyPatch,
-    bms_fixture: str,
     swap: bool,
     bt_discovery: BluetoothServiceInfoBleak,
     hass: HomeAssistant,
 ) -> None:
-    """Test entries are unloaded correctly."""
+    """Test entry is unloaded correctly."""
 
-    bms_class: Final[str] = f"aiobmsble.bms.{bms_fixture}.BMS"
+    bms_class: Final[str] = "aiobmsble.bms.dummy_bms.BMS"
     monkeypatch.setattr(
         f"{bms_class}.device_info", mock_devinfo_min if swap else mock_exception
     )
@@ -43,7 +42,7 @@ async def test_init_fail(
 
     inject_bluetooth_service_info_bleak(hass, bt_discovery)
 
-    cfg: MockConfigEntry = mock_config(bms=bms_fixture)
+    cfg: MockConfigEntry = mock_config(bms="dummy_bms")
     cfg.add_to_hass(hass)
 
     assert not await hass.config_entries.async_setup(cfg.entry_id), (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -163,9 +163,9 @@ async def test_update(
         ),
     ):
         state: State | None = hass.states.get(f"{DEV_NAME}_{sensor}")
-        assert (
-            state is not None and state.attributes[attribute] == value
-        ), f"failed to verify attribute {attribute} for sensor {sensor}"
+        assert state is not None and state.attributes[attribute] == value, (
+            f"failed to verify attribute {attribute} for sensor {sensor}"
+        )
 
     # check battery pack attributes
     for sensor, attribute, ref_value in (


### PR DESCRIPTION
Add a configurable keep_alive option to the options flow, allowing
users to disable persistent BLE connections between update cycles.

When keep_alive is disabled, the Bluetooth adapter is released after
each data fetch, enabling other integrations to connect on hardware
with limited simultaneous BLE connections.

Defaults to True to preserve existing behavior.