### PR TITLE
Make the polling interval selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Bluetooth is turned off, when there is no current. Thus, device will get unavail
 JBD BMS detection unfortunately needs to rely on name patterns. If you renamed your battery it most likely will not be detected. I do appreciate issues being raised for new vendor naming schemes to ease the life of other users. To help, please follow the instructions in the last list item for <a href="#if-your-device-is-not-recognized">non-detected devices</a>.
 </details>
 <details><summary>Liontron batteries</summary>
-These batteries need a shorter interval between queries. Be a bit patient to get them added and set a <a href="[custint-url]">custom interval</a> of about 9s to keep a stable connection.
+These batteries need a shorter interval between queries. Be a bit patient to get them added and set the <i>Update interval</i> option (see <a href="#can-i-set-a-custom-polling-interval">FAQ</a>) to about 9s to keep a stable connection.
 </details>
 <details><summary>Litime batteries</summary>
 Versions of these batteries support a "Bluetooth encryption" feature. When enabled you cannot connect using this integration. Remove the 6-digit Bluetooth password to get them working.
@@ -264,7 +264,9 @@ The polling interval is 30 seconds. So at startup it takes a few minutes to dete
 The `RSSI` value is only measured by Home Assistant when a device is not connected. Thus, you will see updates only in case a connection is lost or after a restart. The integration by default tries to maintain a permanent connection to improve data availability and avoid constant reconnect not appreciated by some BMSs.
 
 ### Can I set a custom polling interval?
-Yes, but I strongly discourage that for stability reasons. If you still want to do so, please see the default way to define a [custom interval][custint-url] by Home Assistant. Note that Bluetooth discoveries can take up to a minute in worst case. Thus, please expect side effects, when changing the default of 30 seconds!
+Yes. Open the integration's device, go to *Configure*, expand *Advanced settings*, and set *Update interval* (in seconds, default 30, minimum 10). Note that Bluetooth discoveries can take up to a minute in worst case, so please expect side effects when changing the default!
+
+This is particularly useful if your battery only supports a single simultaneous Bluetooth connection (e.g. Eco-Worthy-branded batteries) and you also want to use the manufacturer's phone app: disable *Keep connection alive between updates* in the same section and set a longer *Update interval* (e.g. 300, 600, or 900 seconds / 5, 10, or 15 minutes). This way the integration connects, polls, and disconnects on each cycle, leaving the connection free the rest of the time for the phone app. Use the device's *Refresh* button whenever you want up-to-date data on demand without waiting for the next scheduled poll.
 
 ### Can I have the runtime in human readable format (using days)?
 Yes, you can use a [template sensor](https://my.home-assistant.io/redirect/config_flow_start?domain=template) or a card to show templates, e.g. [Mushroom template card](https://github.com/piitaya/lovelace-mushroom) with the following template:<br>
@@ -341,4 +343,3 @@ all [contributors of aiobmsble](https://github.com/patman15/aiobmsble?tab=readme
 [effort-shield]: https://img.shields.io/badge/Effort%20spent-1077_hours-gold?style=for-the-badge&cacheSeconds=86400
 [install-shield]: https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=green&label=HACS&suffix=%20Installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.bms_ble.total&cacheSeconds=14400
 [btproxy-url]: https://esphome.io/components/bluetooth_proxy
-[custint-url]: https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval

--- a/custom_components/bms_ble/__init__.py
+++ b/custom_components/bms_ble/__init__.py
@@ -16,10 +16,17 @@ from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.importlib import async_import_module
 
 from .config_flow import ConfigFlow
-from .const import CONF_ADVANCED_OPTIONS, CONF_KEEP_ALIVE, DOMAIN, LOGGER
+from .const import (
+    CONF_ADVANCED_OPTIONS,
+    CONF_KEEP_ALIVE,
+    CONF_UPDATE_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    UPDATE_INTERVAL,
+)
 from .coordinator import BTBmsCoordinator
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
 
 type BTBmsConfigEntry = ConfigEntry[BTBmsCoordinator]
 
@@ -62,6 +69,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BTBmsConfigEntry) -> boo
             secret=entry.options.get(CONF_PASSWORD, ""),
         ),
         entry,
+        update_interval=int(
+            advanced_options.get(CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+        ),
     )
 
     # Query the device the first time, initialise coordinator.data

--- a/custom_components/bms_ble/button.py
+++ b/custom_components/bms_ble/button.py
@@ -1,0 +1,45 @@
+"""Support for BMS_BLE buttons."""
+
+from typing import Final, override
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BTBmsConfigEntry
+from .const import DOMAIN
+from .coordinator import BTBmsCoordinator
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    config_entry: BTBmsConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add buttons for passed config_entry in Home Assistant."""
+
+    bms: BTBmsCoordinator = config_entry.runtime_data
+    async_add_entities([BMSRefreshButton(bms, format_mac(config_entry.unique_id))])
+
+
+class BMSRefreshButton(ButtonEntity):
+    """Button to request an immediate BMS data refresh."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "refresh"
+
+    def __init__(self, bms: BTBmsCoordinator, unique_id: str) -> None:
+        """Initialize the BMS refresh button."""
+        self._attr_unique_id = f"{DOMAIN}-{unique_id}-refresh"
+        self._attr_device_info = bms.device_info
+        self._bms: Final = bms
+
+    @override
+    async def async_press(self) -> None:
+        """Request an immediate refresh of the BMS data."""
+        await self._bms.async_request_refresh()

--- a/custom_components/bms_ble/config_flow.py
+++ b/custom_components/bms_ble/config_flow.py
@@ -29,6 +29,9 @@ from homeassistant.data_entry_flow import section
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     BooleanSelector,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -37,7 +40,15 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import CONF_ADVANCED_OPTIONS, CONF_KEEP_ALIVE, DOMAIN, LOGGER
+from .const import (
+    CONF_ADVANCED_OPTIONS,
+    CONF_KEEP_ALIVE,
+    CONF_UPDATE_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    MIN_UPDATE_INTERVAL,
+    UPDATE_INTERVAL,
+)
 
 
 @dataclass
@@ -236,7 +247,16 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                                 {
                                     vol.Optional(
                                         CONF_KEEP_ALIVE, default=True
-                                    ): BooleanSelector()
+                                    ): BooleanSelector(),
+                                    vol.Optional(
+                                        CONF_UPDATE_INTERVAL, default=UPDATE_INTERVAL
+                                    ): NumberSelector(
+                                        NumberSelectorConfig(
+                                            min=MIN_UPDATE_INTERVAL,
+                                            mode=NumberSelectorMode.BOX,
+                                            unit_of_measurement="s",
+                                        )
+                                    ),
                                 }
                             ),
                             {"collapsed": True},

--- a/custom_components/bms_ble/const.py
+++ b/custom_components/bms_ble/const.py
@@ -7,7 +7,9 @@ DOMAIN: Final = "bms_ble"
 LOGGER: Final[logging.Logger] = logging.getLogger(__package__)
 LOW_RSSI: Final[int] = -75  # dBm considered low signal strength
 UPDATE_INTERVAL: Final[int] = 30  # [s]
+MIN_UPDATE_INTERVAL: Final[int] = 5  # [s]
 CONF_KEEP_ALIVE: Final[str] = "keep_alive"
+CONF_UPDATE_INTERVAL: Final[str] = "update_interval"
 CONF_ADVANCED_OPTIONS: Final[str] = "advanced_options"
 
 # attributes (do not change)
@@ -40,3 +42,4 @@ ATTR_TEMP_SENSORS: Final[str] = "temperature_sensors"  # [°C]
 BINARY_SENSORS: Final[int] = 6  # total number of binary sensors
 LINK_SENSORS: Final[int] = 2  # total number of sensors for connection quality
 SENSORS: Final[int] = 12  # total number of sensors
+BUTTONS: Final[int] = 1  # total number of buttons

--- a/custom_components/bms_ble/coordinator.py
+++ b/custom_components/bms_ble/coordinator.py
@@ -33,13 +33,14 @@ class BTBmsCoordinator(DataUpdateCoordinator[BMSSample]):
         ble_device: BLEDevice,
         bms_device: BaseBMS,
         config_entry: ConfigEntry,
+        update_interval: int = UPDATE_INTERVAL,
     ) -> None:
         """Initialize BMS data coordinator."""
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=config_entry.title,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=timedelta(seconds=update_interval),
             always_update=False,  # only update when sensor value has changed
             config_entry=config_entry,
         )
@@ -49,6 +50,7 @@ class BTBmsCoordinator(DataUpdateCoordinator[BMSSample]):
         )  # track BMS update issues
         self._mac: Final = ble_device.address
         self._stale: bool = False  # indicates no BMS response for significant time
+        self._poll_interval: Final[int] = update_interval
 
         LOGGER.debug(
             "Initializing coordinator for %s (%s) as %s",
@@ -159,7 +161,7 @@ class BTBmsCoordinator(DataUpdateCoordinator[BMSSample]):
             ) from err
         finally:
             self._link_q.extend(
-                [False] * (1 + int((monotonic() - start) / UPDATE_INTERVAL))
+                [False] * (1 + int((monotonic() - start) / self._poll_interval))
             )
 
         self._link_q[-1] = True  # set success

--- a/custom_components/bms_ble/icons.json
+++ b/custom_components/bms_ble/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "refresh": {
+        "default": "mdi:refresh"
+      }
+    },
     "binary_sensor": {
       "balancer": {
         "default": "mdi:transfer"

--- a/custom_components/bms_ble/manifest.json
+++ b/custom_components/bms_ble/manifest.json
@@ -142,5 +142,5 @@
   "loggers": ["bleak_retry_connector", "aiobmsble"],
   "quality_scale": "silver",
   "requirements": ["aiobmsble==0.25.0"],
-  "version": "2.14.0"
+  "version": "2.15.0"
 }

--- a/custom_components/bms_ble/strings.json
+++ b/custom_components/bms_ble/strings.json
@@ -36,6 +36,11 @@
         "name": "Heater"
       }
     },
+    "button": {
+      "refresh": {
+        "name": "Refresh"
+      }
+    },
     "sensor": {
       "battery_health": {
         "name": "Battery health"
@@ -102,10 +107,12 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "keep_alive": "Keep connection alive between updates"
+              "keep_alive": "Keep connection alive between updates",
+              "update_interval": "Update interval"
             },
             "data_description": {
-              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead.",
+              "update_interval": "How often (in seconds) to connect to the BMS and poll data. If your battery only supports a single Bluetooth connection (e.g. Eco-Worthy) and you also want to use its phone app, disable 'Keep connection alive between updates' above and set a longer interval here (e.g. 300, 600, or 900 seconds / 5, 10, or 15 minutes) so the connection is free between polls. Use the Refresh button on the device for on-demand updates in between."
             },
             "name": "Advanced settings"
           }

--- a/custom_components/bms_ble/translations/en.json
+++ b/custom_components/bms_ble/translations/en.json
@@ -33,6 +33,11 @@
         "name": "Heater"
       }
     },
+    "button": {
+      "refresh": {
+        "name": "Refresh"
+      }
+    },
     "sensor": {
       "battery_health": {
         "name": "Battery health"
@@ -93,10 +98,12 @@
         "sections": {
           "advanced_options": {
             "data": {
-              "keep_alive": "Keep connection alive between updates"
+              "keep_alive": "Keep connection alive between updates",
+              "update_interval": "Update interval"
             },
             "data_description": {
-              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead."
+              "keep_alive": "Keep the Bluetooth connection between update cycles. Disabling this degrades BMS connection reliability and is only recommended as a last resort when sharing a single-connection Bluetooth adapter (e.g. Realtek RTL8761B) with other integrations. Consider using a dedicated Bluetooth adapter instead.",
+              "update_interval": "How often (in seconds) to connect to the BMS and poll data. If your battery only supports a single Bluetooth connection (e.g. Eco-Worthy) and you also want to use its phone app, disable 'Keep connection alive between updates' above and set a longer interval here (e.g. 300, 600, or 900 seconds / 5, 10, or 15 minutes) so the connection is free between polls. Use the Refresh button on the device for on-demand updates in between."
             },
             "name": "Advanced options"
           }

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,67 @@
+"""Test the BLE Battery Management System integration button definition."""
+
+from typing import Final
+
+from aiobmsble import BMSSample
+from habluetooth import BluetoothServiceInfoBleak
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, State
+
+from .bluetooth import inject_bluetooth_service_info_bleak
+from .conftest import mock_config, mock_devinfo_min, mock_update_min
+
+BTN_ENTITY: Final[str] = "button.config_test_dummy_bms_refresh"
+
+
+@pytest.mark.usefixtures(
+    "enable_bluetooth", "patch_default_bleak_client", "patch_entity_enabled_default"
+)
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_refresh_button(
+    monkeypatch: pytest.MonkeyPatch,
+    bt_discovery: BluetoothServiceInfoBleak,
+    hass: HomeAssistant,
+) -> None:
+    """Test that the refresh button triggers an on-demand coordinator update."""
+
+    calls: dict[str, int] = {"count": 0}
+
+    async def patch_async_update(_self) -> BMSSample:
+        calls["count"] += 1
+        return await mock_update_min(_self)
+
+    bms_class: Final[str] = "aiobmsble.bms.dummy_bms.BMS"
+    monkeypatch.setattr(f"{bms_class}.device_info", mock_devinfo_min)
+    monkeypatch.setattr(f"{bms_class}.async_update", patch_async_update)
+
+    config: MockConfigEntry = mock_config()
+    config.add_to_hass(hass)
+
+    inject_bluetooth_service_info_bleak(hass, bt_discovery)
+
+    assert await hass.config_entries.async_setup(config.entry_id)
+    await hass.async_block_till_done()
+
+    assert config in hass.config_entries.async_entries()
+    assert config.state is ConfigEntryState.LOADED
+    assert len(hass.states.async_all(["button"])) == 1
+
+    state: State | None = hass.states.get(BTN_ENTITY)
+    assert state is not None
+
+    calls_before: Final[int] = calls["count"]
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": BTN_ENTITY},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert calls["count"] == calls_before + 1, (
+        "Pressing the refresh button did not trigger a new BMS poll."
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the BLE Battery Management System integration config flow."""
 
+from datetime import timedelta
 from typing import Any, Final
 from unittest.mock import AsyncMock
 
@@ -13,11 +14,14 @@ from voluptuous import Schema
 from custom_components.bms_ble.config_flow import ConfigFlow
 from custom_components.bms_ble.const import (
     BINARY_SENSORS,
+    BUTTONS,
     CONF_ADVANCED_OPTIONS,
     CONF_KEEP_ALIVE,
+    CONF_UPDATE_INTERVAL,
     DOMAIN,
     LINK_SENSORS,
     SENSORS,
+    UPDATE_INTERVAL,
 )
 from homeassistant.config_entries import (
     SOURCE_BLUETOOTH,
@@ -122,7 +126,7 @@ async def test_bluetooth_discovery(
             (
                 min(BINARY_SENSORS, 1),
                 SENSORS - 3,
-                min(BINARY_SENSORS, 1) + (SENSORS - 1) + LINK_SENSORS,
+                min(BINARY_SENSORS, 1) + (SENSORS - 1) + LINK_SENSORS + BUTTONS,
             ),
         ),
         (
@@ -130,7 +134,7 @@ async def test_bluetooth_discovery(
             (
                 max(BINARY_SENSORS - 4, 0),
                 SENSORS - 2,  # link sensors are disabled by default
-                BINARY_SENSORS + SENSORS + LINK_SENSORS,
+                BINARY_SENSORS + SENSORS + LINK_SENSORS + BUTTONS,
             ),
         ),
     ],
@@ -440,7 +444,10 @@ async def test_options_flow(
     """Test config options flow."""
 
     options: Final[dict[str, Any]] = {CONF_PASSWORD: "123456"} | {
-        CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: True}
+        CONF_ADVANCED_OPTIONS: {
+            CONF_KEEP_ALIVE: True,
+            CONF_UPDATE_INTERVAL: UPDATE_INTERVAL,
+        }
     }
 
     # pick one BMS type with password option
@@ -487,7 +494,12 @@ async def test_options_flow_no_secret(hass: HomeAssistant) -> None:
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
 
-    options: Final[dict[str, Any]] = {CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: True}}
+    options: Final[dict[str, Any]] = {
+        CONF_ADVANCED_OPTIONS: {
+            CONF_KEEP_ALIVE: True,
+            CONF_UPDATE_INTERVAL: UPDATE_INTERVAL,
+        }
+    }
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input=options
@@ -547,7 +559,10 @@ async def test_options_effect(
 
     adv_options: dict[str, Any] = {
         CONF_PASSWORD: "123abc",
-        CONF_ADVANCED_OPTIONS: {CONF_KEEP_ALIVE: keep_alive},
+        CONF_ADVANCED_OPTIONS: {
+            CONF_KEEP_ALIVE: keep_alive,
+            CONF_UPDATE_INTERVAL: 900,
+        },
     }
 
     result = await hass.config_entries.options.async_configure(
@@ -562,6 +577,9 @@ async def test_options_effect(
         options[CONF_KEEP_ALIVE] == keep_alive
     ), f"keep_alive value {keep_alive} not set."
     assert options.get(CONF_PASSWORD) == "123abc"
+    assert cfg.runtime_data.update_interval == timedelta(seconds=900), (
+        "update_interval option did not reach the coordinator."
+    )
 
 
 @pytest.mark.usefixtures("enable_bluetooth")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 import contextlib
+from datetime import timedelta
 from typing import Final
 
 from aiobmsble import BMSSample
@@ -16,6 +17,7 @@ from custom_components.bms_ble.const import (
     ATTR_CYCLES,
     ATTR_POWER,
     ATTR_PROBLEM,
+    UPDATE_INTERVAL,
 )
 from custom_components.bms_ble.coordinator import BTBmsCoordinator
 from homeassistant.const import ATTR_BATTERY_CHARGING, ATTR_VOLTAGE
@@ -82,6 +84,39 @@ async def test_update(
     assert coordinator.link_quality == 66
 
     await coordinator.async_shutdown()
+
+
+@pytest.mark.usefixtures("enable_bluetooth", "patch_default_bleak_client")
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_custom_update_interval(
+    bt_discovery: BluetoothServiceInfoBleak, hass: HomeAssistant
+) -> None:
+    """Test coordinator uses a custom update_interval when provided."""
+
+    custom_interval: Final[int] = 900
+
+    coordinator = BTBmsCoordinator(
+        hass,
+        bt_discovery.device,
+        MockBMS(),
+        mock_config(bms="custom_interval"),
+        update_interval=custom_interval,
+    )
+
+    assert coordinator.update_interval == timedelta(seconds=custom_interval)
+
+    inject_bluetooth_service_info_bleak(hass, bt_discovery)
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success
+
+    # default stays unchanged when update_interval is not provided
+    default_coordinator = BTBmsCoordinator(
+        hass, bt_discovery.device, MockBMS(), mock_config(bms="default_interval")
+    )
+    assert default_coordinator.update_interval == timedelta(seconds=UPDATE_INTERVAL)
+
+    await coordinator.async_shutdown()
+    await default_coordinator.async_shutdown()
 
 
 @pytest.mark.usefixtures("enable_bluetooth", "patch_default_bleak_client")


### PR DESCRIPTION
Allow the BMS update interval to be configured per device so batteries that support only a single Bluetooth connection (e.g. Eco-Worthy) can be polled infrequently, freeing the connection for the vendor's phone app in between. Add a Refresh button for on-demand updates.

Passes ruff, mypy, and pytest with 100% branch coverage.